### PR TITLE
Adds headers to Response

### DIFF
--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -241,11 +241,11 @@ class Response(JsonSerializable):
         return self._body
 
     def as_structure(self):
-        inner = {
-            "statusCode": self.status_code,
-            "body": self.body,
-            "headers": self.headers,
-        }
+        inner = { "statusCode": self.status_code }
+        if self.body:
+            inner['body'] = self.body
+        if self.headers:
+            inner['headers'] = self.headers
         result = {"is": inner, "_behaviors": {}}
         if self.wait:
             result["_behaviors"]["wait"] = self.wait

--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -215,7 +215,7 @@ class Proxy(JsonSerializable):
 class Response(JsonSerializable):
     """Represents a Mountebank 'is' response behavior - see http://www.mbtest.org/docs/api/stubs"""
 
-    def __init__(self, body="", status_code=200, wait=None, repeat=None):
+    def __init__(self, body="", status_code=200, wait=None, repeat=None, headers=None):
         """
         :param body: Body text for response. Can be a string, or a JSON serialisable data structure.
         :type body: str or dict or list or xml.etree.ElementTree.Element
@@ -225,11 +225,14 @@ class Response(JsonSerializable):
         :type wait: int
         :param repeat: Repeat this many times before moving on to next response.
         :type repeat: int
+        :param headers: Response HTTP headers
+        :type headers: dict mapping from HTTP header name to header value
         """
         self._body = body
         self.status_code = status_code
         self.wait = wait
         self.repeat = repeat
+        self.headers = headers
 
     @property
     def body(self):
@@ -238,9 +241,11 @@ class Response(JsonSerializable):
         return self._body
 
     def as_structure(self):
-        inner = {"statusCode": self.status_code, "body": self.body}
-        if self.body:
-            inner["body"] = self.body
+        inner = {
+            "statusCode": self.status_code,
+            "body": self.body,
+            "headers": self.headers,
+        }
         result = {"is": inner, "_behaviors": {}}
         if self.wait:
             result["_behaviors"]["wait"] = self.wait

--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -241,11 +241,11 @@ class Response(JsonSerializable):
         return self._body
 
     def as_structure(self):
-        inner = { "statusCode": self.status_code }
+        inner = {"statusCode": self.status_code}
         if self.body:
-            inner['body'] = self.body
+            inner["body"] = self.body
         if self.headers:
-            inner['headers'] = self.headers
+            inner["headers"] = self.headers
         result = {"is": inner, "_behaviors": {}}
         if self.wait:
             result["_behaviors"]["wait"] = self.wait

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -1,0 +1,39 @@
+# encoding=utf-8
+from __future__ import unicode_literals, absolute_import, division, print_function
+
+import logging
+
+import requests
+from brunns.matchers.response import response_with
+from hamcrest import assert_that, is_, has_entry
+
+from mbtest.imposters import Imposter, Response, Stub
+
+logger = logging.getLogger(__name__)
+
+
+def test_body(mock_server):
+    imposter = Imposter(Stub(responses=Response(body="sausages")))
+
+    with mock_server(imposter):
+        response = requests.get(imposter.url)
+
+        assert_that(response, is_(response_with(body="sausages")))
+
+
+def test_status(mock_server):
+    imposter = Imposter(Stub(responses=Response(status_code=204)))
+
+    with mock_server(imposter):
+        response = requests.get(imposter.url)
+
+        assert_that(response, is_(response_with(status_code=204)))
+
+
+def test_headers(mock_server):
+    imposter = Imposter(Stub(responses=Response(headers={"X-Clacks-Overhead": "GNU Terry Pratchett"})))
+
+    with mock_server(imposter):
+        response = requests.get(imposter.url)
+
+        assert_that(response, is_(response_with(headers=has_entry("X-Clacks-Overhead", "GNU Terry Pratchett"))))


### PR DESCRIPTION
Mountebank supports specifying HTTP response headers This adds
`headers` to the `Response` type.