### PR TITLE
Remove pytest as a package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "requests~=2.0",
         "furl~=2.0",
         "pyhamcrest~=1.9",
-        "pytest~=4.0",
         'singledispatch~=3.4;python_version<"3.4"',
         'enum34~=1.0;python_version<"3.4"',
     ],


### PR DESCRIPTION
`pytest` doesn't seem to be a used dependency.
`$ git grep pytest`
```
.gitignore:.pytest_cache/
Makefile:	#pytest --durations=10 --hypothesis-show-statistics test/unit/
Makefile:	#pytest -m"not slow" --durations=10 --hypothesis-show-statistics test/integration/
Makefile:	#pytest --durations=10 test/
Makefile:	rm -rf build/ dist/ *.egg-info/ .cache .coverage .pytest_cache
README.md:Includes [pytest](https://pytest.org) fixture and [PyHamcrest](https://pyhamcrest.readthedocs.io) matchers.
README.md:Needs a [pytest fixture](https://docs.pytest.org/en/latest/fixture.html), most easily defined in [`conftest.py`](https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions):
README.md:import pytest
README.md:@pytest.fixture(scope="session")
src/mbtest/server.py:    Use in a pytest conftest.py fixture as follows:
src/mbtest/server.py:    @pytest.fixture(scope="session")
src/mbtest/server.py:    @pytest.mark.usefixtures("mock_server")
tests/integration/conftest.py:import pytest
tests/integration/conftest.py:@pytest.fixture(scope="session")
tox.ini:    pytest~=4.0
tox.ini:    pytest-cov~=2.5
tox.ini:    pytest --cov {envsitepackagesdir}/mbtest --durations=10 --cov-report term-missing --cov-fail-under 100 --basetemp={envtmpdir} {posargs}
```

The three references in `server.py` are in a comment block.