### PR TITLE
Adds `from_structure` staticmethods

### DIFF
--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -61,9 +61,12 @@ class Imposter(JsonSerializable):
     def from_structure(structure):
         imposter = Imposter(
             [Stub.from_structure(stub) for stub in structure["stubs"]],
-            port=structure["port"],
-            protocol=structure["protocol"],
         )
+        if "port" in structure:
+            imposter.port = structure["port"]
+        if "protocol" in structure:
+            protocol = structure["protocol"]
+            imposter.protocol =  protocol if isinstance(protocol, Imposter.Protocol) else Imposter.Protocol(protocol)
         if "recordRequests" in structure:
             imposter.record_requests = structure["recordRequests"]
         if "name" in structure:

--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -59,14 +59,12 @@ class Imposter(JsonSerializable):
 
     @staticmethod
     def from_structure(structure):
-        imposter = Imposter(
-            [Stub.from_structure(stub) for stub in structure["stubs"]],
-        )
+        imposter = Imposter([Stub.from_structure(stub) for stub in structure["stubs"]])
         if "port" in structure:
             imposter.port = structure["port"]
         if "protocol" in structure:
             protocol = structure["protocol"]
-            imposter.protocol =  protocol if isinstance(protocol, Imposter.Protocol) else Imposter.Protocol(protocol)
+            imposter.protocol = protocol if isinstance(protocol, Imposter.Protocol) else Imposter.Protocol(protocol)
         if "recordRequests" in structure:
             imposter.record_requests = structure["recordRequests"]
         if "name" in structure:

--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -266,9 +266,6 @@ class Proxy(JsonSerializable):
 class Response(JsonSerializable):
     """Represents a Mountebank 'is' response behavior - see http://www.mbtest.org/docs/api/stubs"""
 
-    class InvalidResponse(Exception):
-        pass
-
     class Mode(Enum):
         TEXT = "text"
         BINARY = "binary"
@@ -328,13 +325,7 @@ class Response(JsonSerializable):
         return response
 
     def fields_from_structure(self, structure):
-        types = tuple(filter(lambda key: key != "_behaviors", structure.keys()))
-        if len(types) != 1:
-            # TODO(@colinschoen) This is contradictory to the mountebank contract, but fixing
-            # it will require a more substantial refactor.
-            raise Response.InvalidResponse("Each response must specify exactly one type.")
-        response_type = types[0]
-        inner = structure[response_type]
+        inner = structure["is"]
         if "body" in inner:
             self._body = inner["body"]
         if "headers" in inner:

--- a/src/mbtest/imposters.py
+++ b/src/mbtest/imposters.py
@@ -30,7 +30,7 @@ class Imposter(JsonSerializable):
         HTTPS = "https"
         SMTP = "smtp"
 
-    def __init__(self, stubs, port=4545, protocol=Protocol.HTTP, name=None, record_requests=True):
+    def __init__(self, stubs, port=None, protocol=Protocol.HTTP, name=None, record_requests=True):
         """
         :param stubs: One or more Stubs.
         :type stubs: Stub or list(Stub)
@@ -43,14 +43,18 @@ class Imposter(JsonSerializable):
         :param record_requests: Record requests made against this impostor, so they can be asserted against later.
         :type record_requests: bool
         """
-        self.stubs = stubs if isinstance(stubs, Sequence) else [stubs]
+        stubs = stubs if isinstance(stubs, Sequence) else [stubs]
+        # For backwards compatability where previously a proxy may have been used directly as a stub.
+        self.stubs = [Stub(responses=stub) if isinstance(stub, Proxy) else stub for stub in stubs]
         self.port = port
         self.protocol = protocol if isinstance(protocol, Imposter.Protocol) else Imposter.Protocol(protocol)
         self.name = name
         self.record_requests = record_requests
 
     def as_structure(self):
-        structure = {"protocol": self.protocol.value, "recordRequests": self.record_requests, "port": self.port}
+        structure = {"protocol": self.protocol.value, "recordRequests": self.record_requests}
+        if self.port:
+            structure["port"] = self.port
         if self.name:
             structure["name"] = self.name
         if self.stubs:

--- a/tests/integration/test_imposter.py
+++ b/tests/integration/test_imposter.py
@@ -18,7 +18,6 @@ def test_structure_port():
 def test_structure_no_port():
     expected_imposter = Imposter(Stub())
     imposter_structure = expected_imposter.as_structure()
-    del imposter_structure["port"]
     imposter = Imposter.from_structure(imposter_structure)
     assert imposter.port == expected_imposter.port
 

--- a/tests/integration/test_imposter.py
+++ b/tests/integration/test_imposter.py
@@ -1,0 +1,58 @@
+# encoding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+from mbtest.imposters import Imposter, Stub, Proxy, Response
+
+logger = logging.getLogger(__name__)
+
+
+def test_structure_port():
+    expected_imposter = Imposter(Stub(), port=4546)
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.port == expected_imposter.port
+
+
+def test_structure_response_port():
+    expected_imposter = Imposter(Stub(responses=Response()), port=4546)
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.port == expected_imposter.port
+
+
+def test_structure_proxy_port():
+    expected_imposter = Imposter(Stub(responses=Proxy("http://darwin.dog")), port=4546)
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.port == expected_imposter.port
+
+
+def test_structure_protocol():
+    expected_imposter = Imposter(Stub(), protocol="http")
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.protocol == expected_imposter.protocol
+
+
+def test_structure_name():
+    expected_imposter = Imposter(Stub(), name="darwin")
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.name == expected_imposter.name
+
+
+def test_structure_record_requests():
+    expected_imposter = Imposter(Stub(), record_requests=False)
+    imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.record_requests == expected_imposter.record_requests
+
+
+def test_structure_no_record_requests():
+    expected_imposter = Imposter(Stub())
+    imposter_structure = expected_imposter.as_structure()
+    del imposter_structure["recordRequests"]
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.record_requests == expected_imposter.record_requests

--- a/tests/integration/test_imposter.py
+++ b/tests/integration/test_imposter.py
@@ -15,6 +15,14 @@ def test_structure_port():
     assert imposter.port == expected_imposter.port
 
 
+def test_structure_no_port():
+    expected_imposter = Imposter(Stub())
+    imposter_structure = expected_imposter.as_structure()
+    del imposter_structure["port"]
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.port == expected_imposter.port
+
+
 def test_structure_response_port():
     expected_imposter = Imposter(Stub(responses=Response()), port=4546)
     imposter_structure = expected_imposter.as_structure()
@@ -32,6 +40,14 @@ def test_structure_proxy_port():
 def test_structure_protocol():
     expected_imposter = Imposter(Stub(), protocol="http")
     imposter_structure = expected_imposter.as_structure()
+    imposter = Imposter.from_structure(imposter_structure)
+    assert imposter.protocol == expected_imposter.protocol
+
+
+def test_structure_no_protocol():
+    expected_imposter = Imposter(Stub())
+    imposter_structure = expected_imposter.as_structure()
+    del imposter_structure["protocol"]
     imposter = Imposter.from_structure(imposter_structure)
     assert imposter.protocol == expected_imposter.protocol
 

--- a/tests/integration/test_predicates.py
+++ b/tests/integration/test_predicates.py
@@ -136,4 +136,4 @@ def test_invalid_operator():
     # Adds another operator
     predicate_structure["equals"] = {}
     with pytest.raises(Predicate.InvalidPredicateOperator):
-        predicate = Predicate.from_structure(predicate_structure)
+        Predicate.from_structure(predicate_structure)

--- a/tests/integration/test_predicates.py
+++ b/tests/integration/test_predicates.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 
 import requests
+import pytest
 from brunns.matchers.response import response_with
 from hamcrest import assert_that, is_, not_
 
@@ -85,3 +86,54 @@ def test_methods(mock_server):
         assert_that(post, is_(response_with(body="post")))
         assert_that(put, is_(response_with(body="put")))
         assert_that(get, is_(response_with(body="get")))
+
+
+def test_structure_path():
+    expected_predicate = Predicate(path="/darwin")
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.path == expected_predicate.path
+
+
+def test_structure_body():
+    expected_predicate = Predicate(body="darwin")
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.body == expected_predicate.body
+
+
+def test_structure_method():
+    expected_predicate = Predicate(method="GET")
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.method == expected_predicate.method
+
+
+def test_structure_query():
+    expected_predicate = Predicate(query={"key": "value"})
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.query == expected_predicate.query
+
+
+def test_structure_operator():
+    expected_predicate = Predicate(operator="deepEquals")
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.operator == expected_predicate.operator
+
+
+def test_structure_xpath():
+    expected_predicate = Predicate(xpath="darwin")
+    predicate_structure = expected_predicate.as_structure()
+    predicate = Predicate.from_structure(predicate_structure)
+    assert predicate.xpath == expected_predicate.xpath
+
+
+def test_invalid_operator():
+    expected_predicate = Predicate(operator="deepEquals")
+    predicate_structure = expected_predicate.as_structure()
+    # Adds another operator
+    predicate_structure["equals"] = {}
+    with pytest.raises(Predicate.InvalidPredicateOperator):
+        predicate = Predicate.from_structure(predicate_structure)

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -2,7 +2,6 @@
 import logging
 
 import requests
-import pytest
 from brunns.matchers.html import has_title
 from brunns.matchers.object import between
 from brunns.matchers.response import response_with

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -4,20 +4,21 @@ from __future__ import unicode_literals, absolute_import, division, print_functi
 import logging
 
 import requests
+import pytest
 from brunns.matchers.html import has_title
 from brunns.matchers.object import between
 from brunns.matchers.response import response_with
 from contexttimer import Timer
 from hamcrest import assert_that, is_
 
-from mbtest.imposters import Imposter, Proxy
+from mbtest.imposters import Imposter, Proxy, Stub
 from mbtest.matchers import had_request
 
 logger = logging.getLogger(__name__)
 
 
 def test_proxy(mock_server):
-    imposter = Imposter(Proxy(to="http://example.com"))
+    imposter = Imposter(Stub(responses=Proxy(to="http://example.com")))
 
     with mock_server(imposter) as server:
         response = requests.get("{0}/".format(imposter.url))
@@ -27,7 +28,7 @@ def test_proxy(mock_server):
 
 
 def test_proxy_delay(mock_server):
-    imposter = Imposter(Proxy(to="http://example.com", wait=500))
+    imposter = Imposter(Stub(responses=Proxy(to="http://example.com", wait=500)))
 
     with mock_server(imposter), Timer() as t:
         requests.get("{0}/".format(imposter.url))
@@ -35,3 +36,17 @@ def test_proxy_delay(mock_server):
     assert_that(
         t.elapsed, between(0.5, 0.9)
     )  # Slightly longer than the wait time, to give example.com and the 'net time to work.
+
+
+def test_structure_to():
+    expected_proxy = Proxy("http://darwin.dog")
+    proxy_structure = expected_proxy.as_structure()
+    proxy = Proxy.from_structure(proxy_structure)
+    assert proxy.to == expected_proxy.to
+
+
+def test_structure_wait():
+    expected_proxy = Proxy("http://darwin.dog", wait=200)
+    proxy_structure = expected_proxy.as_structure()
+    proxy = Proxy.from_structure(proxy_structure)
+    assert proxy.wait == expected_proxy.wait

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, absolute_import, division, print_functi
 import logging
 
 import requests
+import pytest
 from brunns.matchers.response import response_with
 from hamcrest import assert_that, is_, has_entry
 
@@ -37,3 +38,55 @@ def test_headers(mock_server):
         response = requests.get(imposter.url)
 
         assert_that(response, is_(response_with(headers=has_entry("X-Clacks-Overhead", "GNU Terry Pratchett"))))
+
+
+def test_structure_headers():
+    expected_response = Response(headers={"X-Clacks-Overhead": "GNU Terry Pratchett"})
+    response_structure = expected_response.as_structure()
+    response = Response.from_structure(response_structure)
+    assert response.headers == expected_response.headers
+
+
+def test_structure_body():
+    expected_response = Response(body="darwin")
+    response_structure = expected_response.as_structure()
+    response = Response.from_structure(response_structure)
+    assert response.body == expected_response.body
+
+
+def test_structure_status():
+    expected_response = Response(status_code=204)
+    response_structure = expected_response.as_structure()
+    response = Response.from_structure(response_structure)
+    assert response.status_code == expected_response.status_code
+
+
+def test_structure_no_status():
+    expected_response = Response()
+    response_structure = expected_response.as_structure()
+    del response_structure["is"]["statusCode"]
+    response = Response.from_structure(response_structure)
+    assert response.status_code == expected_response.status_code
+
+
+def test_structure_repeat():
+    expected_response = Response(repeat=1)
+    response_structure = expected_response.as_structure()
+    response = Response.from_structure(response_structure)
+    assert response.repeat == expected_response.repeat
+
+
+def test_structure_wait():
+    expected_response = Response(wait=300)
+    response_structure = expected_response.as_structure()
+    response = Response.from_structure(response_structure)
+    assert response.wait == expected_response.wait
+
+
+def test_structure_invalid_response():
+    expected_response = Response()
+    response_structure = expected_response.as_structure()
+    # Add another response type
+    response_structure["proxy"] = {}
+    with pytest.raises(Response.InvalidResponse):
+        Response.from_structure(response_structure)

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -88,12 +88,3 @@ def test_structure_wait():
     response_structure = expected_response.as_structure()
     response = Response.from_structure(response_structure)
     assert response.wait == expected_response.wait
-
-
-def test_structure_invalid_response():
-    expected_response = Response()
-    response_structure = expected_response.as_structure()
-    # Add another response type
-    response_structure["proxy"] = {}
-    with pytest.raises(Response.InvalidResponse):
-        Response.from_structure(response_structure)

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -37,7 +37,7 @@ def test_headers(mock_server):
 
         assert_that(response, is_(response_with(headers=has_entry("X-Clacks-Overhead", "GNU Terry Pratchett"))))
 
-        
+
 def test_binary_mode(mock_server):
     imposter = Imposter(Stub(responses=Response(mode=Response.Mode.BINARY, body=b"c2F1c2FnZXM=")))
 
@@ -45,8 +45,8 @@ def test_binary_mode(mock_server):
         response = requests.get(imposter.url)
 
         assert_that(response, is_(response_with(content=b"sausages")))
-        
-        
+
+
 def test_structure_headers():
     expected_response = Response(headers={"X-Clacks-Overhead": "GNU Terry Pratchett"})
     response_structure = expected_response.as_structure()

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -2,7 +2,6 @@
 import logging
 
 import requests
-import pytest
 from brunns.matchers.response import response_with
 from hamcrest import assert_that, is_, has_entry
 


### PR DESCRIPTION
Allows `Imposter`s and related types to be created from the output
of `as_structure`.

`Proxy` modified to be used as a Response inside of a Stub. This
is more consistent with the mountebank contract.