### PR TITLE
Ensure imposter host matches server host

### DIFF
--- a/src/mbtest/imposters/imposters.py
+++ b/src/mbtest/imposters/imposters.py
@@ -36,7 +36,6 @@ class Imposter(JsonSerializable):
         protocol: Protocol = Protocol.HTTP,
         name: Optional[str] = None,
         record_requests: bool = True,
-        host: str = "localhost"
     ) -> None:
         stubs = cast(Iterable[Stub], stubs if isinstance(stubs, abc.Sequence) else [stubs])
         # For backwards compatibility where previously a proxy may have been used directly as a stub.
@@ -49,11 +48,7 @@ class Imposter(JsonSerializable):
         )
         self.name = name
         self.record_requests = record_requests
-        self.host = host
-
-    @property
-    def host(self) -> str:
-        return self.host
+        self.host = "localhost"
 
     @property
     def url(self) -> furl:

--- a/src/mbtest/imposters/imposters.py
+++ b/src/mbtest/imposters/imposters.py
@@ -36,6 +36,7 @@ class Imposter(JsonSerializable):
         protocol: Protocol = Protocol.HTTP,
         name: Optional[str] = None,
         record_requests: bool = True,
+        host: str = "localhost"
     ) -> None:
         stubs = cast(Iterable[Stub], stubs if isinstance(stubs, abc.Sequence) else [stubs])
         # For backwards compatibility where previously a proxy may have been used directly as a stub.
@@ -48,10 +49,11 @@ class Imposter(JsonSerializable):
         )
         self.name = name
         self.record_requests = record_requests
+        self.host = host
 
     @property
     def host(self) -> str:
-        return "localhost"
+        return self.host
 
     @property
     def url(self) -> furl:

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -135,16 +135,23 @@ class MountebankServer:
     def __exit__(self, ex_type, ex_value, ex_traceback) -> None:
         self.delete_imposters()
 
+    def _ensure_imposter_host_matches_server_host(self, imposter: Imposter) -> Imposter:
+        if imposter.host != self.host:
+            imposter.host = self.host
+        return imposter
+
     def add_imposters(self, definition: Union[Imposter, Iterable[Imposter]]) -> None:
         """Add imposters to Mountebank server.
 
         :param definition: One or more Imposters.
         :type definition: Imposter or list(Imposter)
         """
+
         if isinstance(definition, abc.Iterable):
             for imposter in definition:
                 self.add_imposters(imposter)
         else:
+            definition = self._ensure_imposter_host_matches_server_host(imposter=definition)
             json = definition.as_structure()
             post = requests.post(self.server_url, json=json, timeout=10)
             post.raise_for_status()


### PR DESCRIPTION
Allow setting the hostname when creating an imposter, rather than have it hardcoded to `localhost`. 

This is helpful when connecting to a running Mountebank instance in a docker-compose setup in combination with the MountebankServer class - the hostname needs to be the docker-compose service name.

We set the default to localhost for the standard use case.