### PR TITLE
Suppress console output for make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ recreate: ## Recreate tox environments
 
 .PHONY: clean
 clean: ## Clean generated files
-	find . -name '*.pyc' -delete
-	find . -name '*.pyo' -delete
-	rm -rf build/ dist/ *.egg-info/ .cache .coverage .pytest_cache coverage.* coverage.* .mbdb/
-	find . -name "*.egg-info" -type d -print | xargs -t rm -r
-	find . -name "__pycache__" -type d -print | xargs -t rm -r
-	find . -name "test-output" -type d -print | xargs -t rm -r
+	@find . -name '*.pyc' -delete
+	@find . -name '*.pyo' -delete
+	@rm -rf build/ dist/ *.egg-info/ .cache .coverage .pytest_cache coverage.* coverage.* .mbdb/
+	@find . -name "*.egg-info" -type d -print | xargs -t rm -r
+	@find . -name "__pycache__" -type d -print | xargs -t rm -r
+	@find . -name "test-output" -type d -print | xargs -t rm -r
 
 .PHONY: deps
 deps: jsdeps ## Install or update dependencies


### PR DESCRIPTION
Make clean is run before running tests; it often spits out a huge list of deleted folders/files, which distracts from the test output.