### PR TITLE
First steps toward DRY dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,37 @@ except IOError:
     logger.warning("README file not found or unreadable.")
     long_description = "See https://github.com/brunns/mbtest/"
 
+install_dependencies = [
+    "requests~=2.0",
+    "furl~=2.0",
+    "pyhamcrest~=2.0",
+    "more-itertools~=8.0",
+    "Deprecated~=1.2",
+    "brunns-matchers~=2.4",
+]
+test_dependencies = [
+    "pytest~=5.0",
+    "contexttimer~=0.3",
+    "brunns-builder~=0.2",
+]
+
+coverage_dependencies = [
+    "pytest-cov~=2.5",
+    "codacy-coverage~=1.0",
+]
+
+docs_dependencies = [
+    "sphinx~=2.4",
+    "sphinx-autodoc-typehints~=1.10",
+]
+
+extras = {
+    "install": install_dependencies,
+    "test": test_dependencies,
+    "coverage": coverage_dependencies,
+    "docs": docs_dependencies,
+}
+
 setup(
     name="mbtest",
     zip_safe=False,
@@ -47,12 +78,7 @@ setup(
         "Topic :: Software Development :: Testing",
     ],
     python_requires=">=3.5",
-    install_requires=[
-        "requests~=2.0",
-        "furl~=2.0",
-        "pyhamcrest~=2.0",
-        "more-itertools~=8.0",
-        "Deprecated~=1.2",
-        "brunns-matchers~=2.4",
-    ],
+    install_requires=install_dependencies,
+    tests_require=test_dependencies,
+    extras_require=extras,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,8 @@ whitelist_externals =
     find
     sed
     bash
-deps =
-    pytest~=5.0
-    contexttimer~=0.3
-    brunns-builder~=0.2
+extras =
+    test
 commands =
     {posargs:py.test} tests/unit/ tests/integration/
     {[cleanup]commands}
@@ -18,9 +16,9 @@ usedevelop=True
 
 [testenv:coverage]
 envlist = py38
-deps =
-    {[testenv]deps}
-    pytest-cov~=2.5
+extras =
+    test
+    coverage
 commands =
     pytest --cov {envsitepackagesdir}/mbtest --durations=10 --cov-report term-missing --cov-fail-under 100 --basetemp={envtmpdir} {posargs}
     {[cleanup]commands}
@@ -29,9 +27,9 @@ usedevelop=False
 [testenv:publish-coverage]
 envlist = py38
 passenv = TRAVIS TRAVIS_* CODACY_*
-deps =
-    {[testenv:coverage]deps}
-    codacy-coverage~=1.0
+extras =
+    test
+    coverage
 commands =
     pytest --cov {envsitepackagesdir}/mbtest --cov-report xml --cov-fail-under 100 --basetemp={envtmpdir} {posargs}
     sed -i 's/\/home\/travis\/build\/brunns\/mbtest\/.tox\/publish-coverage\/lib\/python3..\/site-packages/src/g' coverage.xml
@@ -78,31 +76,25 @@ deps =
 commands =
     bandit -r src/
 
-[base] ; Needs to match as setup.py's install_requires. TODO - DRY.
-deps =
-    requests~=2.0
-    furl~=2.0
-    pyhamcrest>=1.9,<3.0
-    more-itertools~=8.0
-    pytest~=5.0
-
 [testenv:pylint]
 basepython = python3
 skip_install = true
+extras =
+    test
+    install
 deps =
     pylint~=2.2
-    {[testenv]deps}
-    {[base]deps}
 commands =
     pylint --disable=C src/
 
 [testenv:mypy]
 basepython = python3
-skip_install = true
+skip_install = false
+extras =
+    test
+    install
 deps =
     mypy~=0.76
-    {[testenv]deps}
-    {[base]deps}
 commands =
     mypy src/ {posargs}
 
@@ -144,12 +136,11 @@ use_parentheses=True
 line_length=100
 
 [testenv:docs]
-description = invoke sphinx-build to build the HTML docs
+description = Invoke sphinx-build to build the HTML docs
 basepython = python3
-deps =
-    sphinx~=2.4
-    sphinx-autodoc-typehints~=1.10
-    {[base]deps}
+extras =
+    install
+    docs
 commands = sphinx-build docs "{toxinidir}/build_docs" --color -W -bhtml {posargs}
            python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "build_docs" / "index.html"))'
 


### PR DESCRIPTION
This uses the tox `extras` option to retrieve dependencies from `setup.py`, meaning that `setup.py` can be the single source of truth for dependencies. (This will be useful for  Dockerised dev setup, allowing us to avoid the need for a `requirements.txt` file completely.)