### PR TITLE
Increase margin of error when testing proxy delay

### DIFF
--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -62,7 +62,7 @@ def test_proxy_delay(mock_server):
         with Timer() as timer:
             requests.get(proxy_imposter.url / "test")
 
-            assert_that(timer.elapsed, between(0.1, 0.15))
+            assert_that(timer.elapsed, between(0.1, 0.2))
 
 
 def test_inject_headers(mock_server):


### PR DESCRIPTION
This test is network-dependent, and thus dependent on the host system, so needs a little more wiggle room to make sure it's not too flaky. (Whilst running in a Docker container, the observed delay in the response was, on average, 0.17s.)