### PR TITLE
Support for adding stubs to an existing imposter

### DIFF
--- a/src/mbtest/imposters/stubs.py
+++ b/src/mbtest/imposters/stubs.py
@@ -47,3 +47,39 @@ class Stub(JsonSerializable):
             [Predicate.from_structure(predicate) for predicate in structure.get("predicates", ())],
             responses,
         )
+
+
+class AddStub(JsonSerializable):
+    """Represents a `Mountebank add stub request <http://www.mbtest.org/docs/api/overview#add-stub>`.
+    To add new stab to an existing imposter.
+
+    :param index: The index in imposter stubs array.
+     If you leave off the index field, the stub will be added to the end of the existing stubs array.
+    :param stub: The stub that will be added to the existing stubs array
+    """
+
+    def __init__(
+            self,
+            stub: Stub = None,
+            index: int = None,
+    ) -> None:
+        self.index = index
+        if stub:
+            self.stub = stub
+        else:
+            self.stub = Stub()
+
+    def as_structure(self) -> JsonStructure:
+        structure = {
+            "stub": self.stub.as_structure(),
+        }
+        if self.index is not None:
+            structure["index"] = self.index
+        return structure
+
+    @staticmethod
+    def from_structure(structure: JsonStructure) -> "AddStub":
+        return AddStub(
+            index=structure.get("index"),
+            stub=structure.get("stub"),
+        )

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -13,8 +13,9 @@ from _pytest.fixtures import FixtureRequest  # type: ignore
 from furl import furl
 from requests import RequestException
 
-from mbtest.imposters import Imposter
+from mbtest.imposters import Imposter, Stub
 from mbtest.imposters.imposters import Request
+from mbtest.imposters.stubs import AddStub
 
 DEFAULT_MB_EXECUTABLE = str(
     Path("node_modules") / ".bin" / ("mb.cmd" if platform.system() == "Windows" else "mb")
@@ -123,10 +124,10 @@ class MountebankServer:
         self.host = host
         self.scheme = scheme
         self.imposters_path = imposters_path
+        self._running_imposters: MutableSequence[Imposter] = []
 
     def __call__(self, imposters: Sequence[Imposter]) -> "MountebankServer":
         self.imposters = imposters
-        self._running_imposters: MutableSequence[Imposter] = []
         return self
 
     def __enter__(self) -> "MountebankServer":
@@ -151,6 +152,26 @@ class MountebankServer:
             post.raise_for_status()
             definition.attach(self.host, post.json()["port"], self.server_url)
             self._running_imposters.append(definition)
+
+    def add_stabs(self, port: int, definition: Union[Stub, Iterable[Stub]]):
+        imposter = self.get_imposter_by_port(port)
+        if not imposter:
+            return self.add_imposters(Imposter(definition, port=port))
+        if isinstance(definition, abc.Iterable):
+            for stub in definition:
+                self.add_stabs(port, stub)
+        else:
+            json = AddStub(definition).as_structure()
+            post = requests.post(f"{self.server_url}/{port}/stubs", json=json, timeout=10)
+            post.raise_for_status()
+            imposter.stubs.append(definition)
+            self._running_imposters.append(imposter)
+
+    def get_imposter_by_port(self, port):
+        imposter = next((imp for imp in self.query_all_imposters() if imp.port == port), None)
+        if imposter:
+            imposter.attach(self.host, port, self.server_url)
+        return imposter
 
     def delete_imposters(self) -> None:
         while self._running_imposters:
@@ -242,7 +263,7 @@ class ExecutingMountebankServer(MountebankServer):
 
     @staticmethod
     def _build_options(
-        port: int, debug: bool, allow_injection: bool, local_only: bool, data_dir: Union[str, None]
+            port: int, debug: bool, allow_injection: bool, local_only: bool, data_dir: Union[str, None]
     ):
         options: List[str] = ["start", "--port", str(port)]
         if debug:

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -153,13 +153,13 @@ class MountebankServer:
             definition.attach(self.host, post.json()["port"], self.server_url)
             self._running_imposters.append(definition)
 
-    def add_stabs(self, port: int, definition: Union[Stub, Iterable[Stub]]):
+    def add_stabs(self, definition: Union[Stub, Iterable[Stub]], port: int):
         imposter = self.get_imposter_by_port(port)
         if not imposter:
             return self.add_imposters(Imposter(definition, port=port))
         if isinstance(definition, abc.Iterable):
             for stub in definition:
-                self.add_stabs(port, stub)
+                self.add_stabs(stub, port)
         else:
             json = AddStub(definition).as_structure()
             post = requests.post(f"{self.server_url}/{port}/stubs", json=json, timeout=10)

--- a/tests/integration/test_add_stabs.py
+++ b/tests/integration/test_add_stabs.py
@@ -14,7 +14,7 @@ def test_not_existing_imposter_single_stub(mock_server):
     port = 4567
     with mock_server([]) as s:
         logger.debug("server: %s", s)
-        mock_server.add_stabs(port, stub)
+        mock_server.add_stabs(stub, port)
         imposter = mock_server.get_imposter_by_port(port)
         r1 = requests.get(f"{imposter.url}/test1")
     assert_that(r1, is_response().with_body("sausages"))
@@ -28,7 +28,7 @@ def test_not_existing_imposter_multiple_stubs(mock_server):
     port = 4567
     with mock_server([]) as s:
         logger.debug("server: %s", s)
-        mock_server.add_stabs(port, stubs)
+        mock_server.add_stabs(stubs, port)
         imposter = mock_server.get_imposter_by_port(port)
         r1 = requests.get(f"{imposter.url}/test1")
         r2 = requests.get(f"{imposter.url}/test2")
@@ -51,7 +51,7 @@ def test_existing_imposter_multiple_stubs(mock_server):
     ]
     with mock_server(existing_imposter) as s:
         logger.debug("server: %s", s)
-        mock_server.add_stabs(existing_imposter.port, stubs)
+        mock_server.add_stabs(stubs, existing_imposter.port)
         imposter = mock_server.get_imposter_by_port(existing_imposter.port)
         responses = [requests.get(f"{imposter.url}/test{i}") for i in range(1, 5)]
     for number, response in enumerate(responses, start=1):

--- a/tests/integration/test_add_stabs.py
+++ b/tests/integration/test_add_stabs.py
@@ -1,0 +1,58 @@
+import logging
+
+import requests
+from brunns.matchers.response import is_response
+from hamcrest import assert_that
+
+from mbtest.imposters import Stub, Predicate, Response, Imposter
+
+logger = logging.getLogger(__name__)
+
+
+def test_not_existing_imposter_single_stub(mock_server):
+    stub = Stub(Predicate(path="/test1"), Response(body="sausages"))
+    port = 4567
+    with mock_server([]) as s:
+        logger.debug("server: %s", s)
+        mock_server.add_stabs(port, stub)
+        imposter = mock_server.get_imposter_by_port(port)
+        r1 = requests.get(f"{imposter.url}/test1")
+    assert_that(r1, is_response().with_body("sausages"))
+
+
+def test_not_existing_imposter_multiple_stubs(mock_server):
+    stubs = [
+        Stub(Predicate(path="/test1"), Response(body="sausages")),
+        Stub(Predicate(path="/test2"), Response(body="chips")),
+    ]
+    port = 4567
+    with mock_server([]) as s:
+        logger.debug("server: %s", s)
+        mock_server.add_stabs(port, stubs)
+        imposter = mock_server.get_imposter_by_port(port)
+        r1 = requests.get(f"{imposter.url}/test1")
+        r2 = requests.get(f"{imposter.url}/test2")
+    assert_that(r1, is_response().with_body("sausages"))
+    assert_that(r2, is_response().with_body("chips"))
+
+
+def test_existing_imposter_multiple_stubs(mock_server):
+    existing_imposter = Imposter(
+        [
+            Stub(Predicate(path="/test1"), Response(body="response1")),
+            Stub(Predicate(path="/test2"), Response(body="response2")),
+        ],
+        port=4567,
+        name="bill",
+    )
+    stubs = [
+        Stub(Predicate(path="/test3"), Response(body="response3")),
+        Stub(Predicate(path="/test4"), Response(body="response4")),
+    ]
+    with mock_server(existing_imposter) as s:
+        logger.debug("server: %s", s)
+        mock_server.add_stabs(existing_imposter.port, stubs)
+        imposter = mock_server.get_imposter_by_port(existing_imposter.port)
+        responses = [requests.get(f"{imposter.url}/test{i}") for i in range(1, 5)]
+    for number, response in enumerate(responses, start=1):
+        assert_that(response, is_response().with_body(f"response{number}"))


### PR DESCRIPTION
Hi! 
Someone uses a shared mountebank server on an exact port and runs tests via pytest-xdist in a distributed manner (as we do). So an imposter is created once should not be deleted since another thread might currently query it.
Mountebank currently has this functionality http://www.mbtest.org/docs/api/overview#change-stub .
I tried to implement this behavior for mbtest.