### PR TITLE
Update DEFAULT_MB_EXECUTABLE to search home and PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ def mock_server(request):
 This will take care of starting and stopping the Mountebank server for you. Examples of more complex predicates can be 
 found in the [integration tests](https://github.com/brunns/mbtest/tree/master/tests/integration/).
 
-See the [Dounumentation](https://mbtest.readthedocs.io/) for more.
+See the [Documentation](https://mbtest.readthedocs.io/) for more.
 
 
 ## Contributing

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras = {
 setup(
     name="mbtest",
     zip_safe=False,
-    version="2.8.1",
+    version="2.8.2",
     description="Python wrapper & utils for the Mountebank over the wire test double tool.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -5,6 +5,7 @@ import platform
 import subprocess  # nosec
 import time
 from collections import abc
+from os.path import expanduser
 from pathlib import Path
 from threading import Lock
 from typing import Iterable, Iterator, List, MutableSequence, Sequence, Set, Union
@@ -17,8 +18,6 @@ from requests import RequestException
 from mbtest.imposters import Imposter
 from mbtest.imposters.imposters import Request
 
-from os.path import expanduser
-
 DEFAULT_MB_PATH = Path("node_modules") / ".bin"
 
 
@@ -30,13 +29,11 @@ def find_mountebank_install():
     if platform.system() != "Windows":
         # Look for file in user home directory (NPM local install)
         user_dir = expanduser("~")
-        current_user_bin = (
-            Path(user_dir) / "node_modules" / ".bin" / DEFAULT_MB_NAME
-        )
+        current_user_bin = Path(user_dir) / "node_modules" / ".bin" / DEFAULT_MB_NAME
         if current_user_bin.is_file() or current_user_bin.is_symlink():
             return str(current_user_bin)
         # Try all paths in the users PATH env
-        for PATH in os.environ.get('PATH').split(":"):
+        for PATH in os.environ.get("PATH").split(":"):
             usr_bin = Path(PATH) / DEFAULT_MB_NAME
             if usr_bin.is_file() or usr_bin.is_symlink():
                 return str(usr_bin)

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -26,15 +26,14 @@ logger = logging.getLogger(__name__)
 
 def find_mountebank_install():
     DEFAULT_MB_NAME = Path("mb.cmd" if platform.system() == "Windows" else "mb")
-    if platform.system() != "Windows":
-        # Try all paths in the users PATH env
-        paths = [str(Path(expanduser("~")) / "node_modules" / ".bin")] + os.environ.get(
-            "PATH"
-        ).split(":")
-        for PATH in paths:
-            usr_bin = Path(PATH) / DEFAULT_MB_NAME
-            if usr_bin.is_file() or usr_bin.is_symlink():
-                return str(usr_bin)
+    HOME_PATH = str(Path(expanduser("~")) / "node_modules" / ".bin")
+
+    # Try all paths in the users PATH env
+    paths = [HOME_PATH] + os.environ.get("PATH").split(":")
+    for PATH in paths:
+        usr_bin = Path(PATH) / DEFAULT_MB_NAME
+        if usr_bin.is_file() or usr_bin.is_symlink():
+            return str(usr_bin)
     return str(DEFAULT_MB_PATH / DEFAULT_MB_NAME)
 
 

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -195,9 +195,7 @@ class MountebankServer:
         server_info = requests.get(self.server_url)
         imposters = server_info.json()["imposters"]
         for imposter in imposters:
-            yield Imposter.from_structure(
-                requests.get(imposter["_links"]["self"]["href"]).json()
-            )
+            yield Imposter.from_structure(requests.get(imposter["_links"]["self"]["href"]).json())
 
 
 class ExecutingMountebankServer(MountebankServer):
@@ -249,13 +247,9 @@ class ExecutingMountebankServer(MountebankServer):
         super().__init__(port)
         with self.start_lock:
             if self.server_port in self.running:
-                raise MountebankPortInUseException(
-                    f"Already running on port {self.server_port}."
-                )
+                raise MountebankPortInUseException(f"Already running on port {self.server_port}.")
             try:
-                options = self._build_options(
-                    port, debug, allow_injection, local_only, data_dir
-                )
+                options = self._build_options(port, debug, allow_injection, local_only, data_dir)
                 self.mb_process = subprocess.Popen([executable] + options)  # nosec
                 self._await_start(timeout)
                 self.running.add(port)
@@ -303,9 +297,7 @@ class ExecutingMountebankServer(MountebankServer):
                 time.sleep(0.1)
 
         if not started:
-            raise MountebankTimeoutError(
-                f"Mountebank failed to start within {timeout} seconds."
-            )
+            raise MountebankTimeoutError(f"Mountebank failed to start within {timeout} seconds.")
 
         logger.debug("Server started at %s.", self.server_url)
 

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -27,13 +27,11 @@ logger = logging.getLogger(__name__)
 def find_mountebank_install():
     DEFAULT_MB_NAME = Path("mb.cmd" if platform.system() == "Windows" else "mb")
     if platform.system() != "Windows":
-        # Look for file in user home directory (NPM local install)
-        user_dir = expanduser("~")
-        current_user_bin = Path(user_dir) / "node_modules" / ".bin" / DEFAULT_MB_NAME
-        if current_user_bin.is_file() or current_user_bin.is_symlink():
-            return str(current_user_bin)
         # Try all paths in the users PATH env
-        for PATH in os.environ.get("PATH").split(":"):
+        paths = [str(Path(expanduser("~")) / "node_modules" / ".bin")] + os.environ.get(
+            "PATH"
+        ).split(":")
+        for PATH in paths:
             usr_bin = Path(PATH) / DEFAULT_MB_NAME
             if usr_bin.is_file() or usr_bin.is_symlink():
                 return str(usr_bin)
@@ -195,7 +193,9 @@ class MountebankServer:
         server_info = requests.get(self.server_url)
         imposters = server_info.json()["imposters"]
         for imposter in imposters:
-            yield Imposter.from_structure(requests.get(imposter["_links"]["self"]["href"]).json())
+            yield Imposter.from_structure(
+                requests.get(imposter["_links"]["self"]["href"]).json()
+            )
 
 
 class ExecutingMountebankServer(MountebankServer):
@@ -247,9 +247,13 @@ class ExecutingMountebankServer(MountebankServer):
         super().__init__(port)
         with self.start_lock:
             if self.server_port in self.running:
-                raise MountebankPortInUseException(f"Already running on port {self.server_port}.")
+                raise MountebankPortInUseException(
+                    f"Already running on port {self.server_port}."
+                )
             try:
-                options = self._build_options(port, debug, allow_injection, local_only, data_dir)
+                options = self._build_options(
+                    port, debug, allow_injection, local_only, data_dir
+                )
                 self.mb_process = subprocess.Popen([executable] + options)  # nosec
                 self._await_start(timeout)
                 self.running.add(port)
@@ -297,7 +301,9 @@ class ExecutingMountebankServer(MountebankServer):
                 time.sleep(0.1)
 
         if not started:
-            raise MountebankTimeoutError(f"Mountebank failed to start within {timeout} seconds.")
+            raise MountebankTimeoutError(
+                f"Mountebank failed to start within {timeout} seconds."
+            )
 
         logger.debug("Server started at %s.", self.server_url)
 

--- a/src/mbtest/server.py
+++ b/src/mbtest/server.py
@@ -193,9 +193,7 @@ class MountebankServer:
         server_info = requests.get(self.server_url)
         imposters = server_info.json()["imposters"]
         for imposter in imposters:
-            yield Imposter.from_structure(
-                requests.get(imposter["_links"]["self"]["href"]).json()
-            )
+            yield Imposter.from_structure(requests.get(imposter["_links"]["self"]["href"]).json())
 
 
 class ExecutingMountebankServer(MountebankServer):
@@ -247,13 +245,9 @@ class ExecutingMountebankServer(MountebankServer):
         super().__init__(port)
         with self.start_lock:
             if self.server_port in self.running:
-                raise MountebankPortInUseException(
-                    f"Already running on port {self.server_port}."
-                )
+                raise MountebankPortInUseException(f"Already running on port {self.server_port}.")
             try:
-                options = self._build_options(
-                    port, debug, allow_injection, local_only, data_dir
-                )
+                options = self._build_options(port, debug, allow_injection, local_only, data_dir)
                 self.mb_process = subprocess.Popen([executable] + options)  # nosec
                 self._await_start(timeout)
                 self.running.add(port)
@@ -301,9 +295,7 @@ class ExecutingMountebankServer(MountebankServer):
                 time.sleep(0.1)
 
         if not started:
-            raise MountebankTimeoutError(
-                f"Mountebank failed to start within {timeout} seconds."
-            )
+            raise MountebankTimeoutError(f"Mountebank failed to start within {timeout} seconds.")
 
         logger.debug("Server started at %s.", self.server_url)
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -70,7 +70,8 @@ def test_server_can_be_restarted_on_same_port():
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Can only run one server on Windows for some reason."
+    platform.system() == "Windows",
+    reason="Can only run one server on Windows for some reason.",
 )
 def test_allow_multiple_servers_on_different_ports():
     # Given
@@ -104,11 +105,23 @@ def test_query_all_imposters(mock_server):
             contains_inanyorder(
                 has_identical_properties_to(
                     imposter1,
-                    ignoring={"host", "url", "server_url", "configuration_url", "attached"},
+                    ignoring={
+                        "host",
+                        "url",
+                        "server_url",
+                        "configuration_url",
+                        "attached",
+                    },
                 ),
                 has_identical_properties_to(
                     imposter2,
-                    ignoring={"host", "url", "server_url", "configuration_url", "attached"},
+                    ignoring={
+                        "host",
+                        "url",
+                        "server_url",
+                        "configuration_url",
+                        "attached",
+                    },
                 ),
             ),
         )

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -1,14 +1,13 @@
 # encoding=utf-8
 import logging
 import os
-from unittest.mock import patch, MagicMock
+import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from mbtest.server import (
-    DEFAULT_MB_EXECUTABLE,
-    find_mountebank_install,
-    ExecutingMountebankServer,
-)
+import pytest
+
+from mbtest.server import DEFAULT_MB_EXECUTABLE, ExecutingMountebankServer, find_mountebank_install
 
 logger = logging.getLogger(__name__)
 
@@ -16,23 +15,18 @@ logger = logging.getLogger(__name__)
 def test_find_mountebank_install(monkeypatch):
     linux_mb_name = "mb"
     windows_mb_name = "mb.cmd"
-    user_home = "%shome%suser" % (os.sep, os.sep)
-    user_bin = "node_modules%s.bin" % os.sep
+    user_home = Path("home")
+    user_bin = Path("node_modules") / ".bin"
 
     with patch("platform.system", return_value="Windows"):
-        assert find_mountebank_install() == "%s%s%s" % (
-            user_bin,
-            os.sep,
-            windows_mb_name,
-        )
+        assert find_mountebank_install() == str(user_bin / windows_mb_name)
 
     monkeypatch.setenv("HOME", user_home)
+    monkeypatch.setenv("USERPROFILE", user_home)
     with patch("platform.system", return_value="Linux"):
         with patch("pathlib.Path.is_file", return_value=True):
-            assert find_mountebank_install() == "%s/%s/%s" % (
-                user_home,
-                user_bin,
-                linux_mb_name,
+            assert find_mountebank_install() == str(
+                user_home / user_bin / linux_mb_name
             )
 
 

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -3,12 +3,7 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
-
-from mbtest.server import (
-    DEFAULT_MB_EXECUTABLE,
-    ExecutingMountebankServer,
-    find_mountebank_install,
-)
+from mbtest.server import DEFAULT_MB_EXECUTABLE, ExecutingMountebankServer, find_mountebank_install
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -1,13 +1,14 @@
 # encoding=utf-8
 import logging
-import os
-import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 
-from mbtest.server import DEFAULT_MB_EXECUTABLE, ExecutingMountebankServer, find_mountebank_install
+from mbtest.server import (
+    DEFAULT_MB_EXECUTABLE,
+    ExecutingMountebankServer,
+    find_mountebank_install,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,9 @@ def test_find_mountebank_install(monkeypatch):
     monkeypatch.setenv("USERPROFILE", user_home)
     with patch("platform.system", return_value="Linux"):
         with patch("pathlib.Path.is_file", return_value=True):
-            assert find_mountebank_install() == str(user_home / user_bin / linux_mb_name)
+            assert find_mountebank_install() == str(
+                user_home / user_bin / linux_mb_name
+            )
 
 
 def test_server_default_options():

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -1,5 +1,6 @@
 # encoding=utf-8
 import logging
+import os
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
@@ -15,11 +16,15 @@ logger = logging.getLogger(__name__)
 def test_find_mountebank_install(monkeypatch):
     linux_mb_name = "mb"
     windows_mb_name = "mb.cmd"
-    user_home = "/home/user"
-    user_bin = "node_modules/.bin"
+    user_home = "%shome%suser" % (os.sep, os.sep)
+    user_bin = "node_modules%s.bin" % os.sep
 
     with patch("platform.system", return_value="Windows"):
-        assert find_mountebank_install() == "%s/%s" % (user_bin, windows_mb_name)
+        assert find_mountebank_install() == "%s%s%s" % (
+            user_bin,
+            os.sep,
+            windows_mb_name,
+        )
 
     monkeypatch.setenv("HOME", user_home)
     with patch("platform.system", return_value="Linux"):

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -14,11 +14,23 @@ def test_find_mountebank_install(monkeypatch):
     user_home = Path("home")
     user_bin = Path("node_modules") / ".bin"
 
-    with patch("platform.system", return_value="Windows"):
-        assert find_mountebank_install() == str(user_bin / windows_mb_name)
+    with patch("platform.system", return_value="Linux"):
+        with patch("pathlib.Path.is_file", return_value=False):
+            with patch("pathlib.Path.is_symlink", return_value=False):
+                assert find_mountebank_install() == str(user_bin / linux_mb_name)
 
-    monkeypatch.setenv("HOME", user_home)
-    monkeypatch.setenv("USERPROFILE", user_home)
+    with patch("platform.system", return_value="Windows"):
+        with patch("pathlib.Path.is_file", return_value=False):
+            with patch("pathlib.Path.is_symlink", return_value=False):
+                assert find_mountebank_install() == str(user_bin / windows_mb_name)
+
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+
+    with patch("platform.system", return_value="Windows"):
+        with patch("pathlib.Path.is_file", return_value=True):
+            assert find_mountebank_install() == str(user_home / user_bin / windows_mb_name)
+
     with patch("platform.system", return_value="Linux"):
         with patch("pathlib.Path.is_file", return_value=True):
             assert find_mountebank_install() == str(user_home / user_bin / linux_mb_name)

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -21,9 +21,7 @@ def test_find_mountebank_install(monkeypatch):
     monkeypatch.setenv("USERPROFILE", user_home)
     with patch("platform.system", return_value="Linux"):
         with patch("pathlib.Path.is_file", return_value=True):
-            assert find_mountebank_install() == str(
-                user_home / user_bin / linux_mb_name
-            )
+            assert find_mountebank_install() == str(user_home / user_bin / linux_mb_name)
 
 
 def test_server_default_options():

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -1,10 +1,34 @@
 # encoding=utf-8
 import logging
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from pathlib import Path
 
-from mbtest.server import DEFAULT_MB_EXECUTABLE, ExecutingMountebankServer
+from mbtest.server import (
+    DEFAULT_MB_EXECUTABLE,
+    find_mountebank_install,
+    ExecutingMountebankServer,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def test_find_mountebank_install(monkeypatch):
+    linux_mb_name = "mb"
+    windows_mb_name = "mb.cmd"
+    user_home = "/home/user"
+    user_bin = "node_modules/.bin"
+
+    with patch("platform.system", return_value="Windows"):
+        assert find_mountebank_install() == "%s/%s" % (user_bin, windows_mb_name)
+
+    monkeypatch.setenv("HOME", user_home)
+    with patch("platform.system", return_value="Linux"):
+        with patch("pathlib.Path.is_file", return_value=True):
+            assert find_mountebank_install() == "%s/%s/%s" % (
+                user_home,
+                user_bin,
+                linux_mb_name,
+            )
 
 
 def test_server_default_options():

--- a/tests/unit/mbtest/test_server.py
+++ b/tests/unit/mbtest/test_server.py
@@ -25,9 +25,7 @@ def test_find_mountebank_install(monkeypatch):
     monkeypatch.setenv("USERPROFILE", user_home)
     with patch("platform.system", return_value="Linux"):
         with patch("pathlib.Path.is_file", return_value=True):
-            assert find_mountebank_install() == str(
-                user_home / user_bin / linux_mb_name
-            )
+            assert find_mountebank_install() == str(user_home / user_bin / linux_mb_name)
 
 
 def test_server_default_options():


### PR DESCRIPTION
The existing DEFAULT_MB_EXECUTABLE uses a hard coded value and causes tests to fail

This adds a function to attempt to find the mountebank executable