### PR TITLE
Add `imurl` to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ except IOError:
 install_dependencies = [
     "requests>=2.0",
     "furl>=2.0",
+    "imurl>=0.2",
     "pyhamcrest>=2.0",
     "Deprecated>=1.2",
     "brunns-matchers>=2.4",


### PR DESCRIPTION
This library is used but is missing from the dependency list

https://github.com/brunns/mbtest/blob/841744761d2790c1e4a89f8d99f3a764f8b75dcc/src/mbtest/matchers.py#L12

https://github.com/brunns/mbtest/blob/841744761d2790c1e4a89f8d99f3a764f8b75dcc/src/mbtest/imposters/responses.py#L9